### PR TITLE
Add middleware to handle timezones

### DIFF
--- a/dtf/middleware.py
+++ b/dtf/middleware.py
@@ -1,10 +1,12 @@
 
 from django.utils import timezone
+from django.conf import settings
 
 class TimezoneMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        timezone.activate("Europe/Berlin") # TODO: get user timezone
+        # TODO: get timezone from user profile when users have been implemented.
+        timezone.activate(settings.DTF_DEFAULT_DISPLAY_TIME_ZONE)
         return self.get_response(request)

--- a/dtf/middleware.py
+++ b/dtf/middleware.py
@@ -1,0 +1,10 @@
+
+from django.utils import timezone
+
+class TimezoneMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        timezone.activate("Europe/Berlin") # TODO: get user timezone
+        return self.get_response(request)

--- a/rest/settings.py
+++ b/rest/settings.py
@@ -135,3 +135,7 @@ STATIC_URL = '/static/'
 
 # https://github.com/wagtail/wagtail/issues/4254
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
+
+# The default time zone to present dates/times in the front end
+# when no user is logged in.
+DTF_DEFAULT_DISPLAY_TIME_ZONE = "UTC"

--- a/rest/settings.py
+++ b/rest/settings.py
@@ -60,6 +60,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'dtf.middleware.TimezoneMiddleware'
 ]
 
 ROOT_URLCONF = 'rest.urls'


### PR DESCRIPTION
This MR adds some very limited middleware to handle timezones.

The instance owner can now edit the setting `DTF_DEFAULT_DISPLAY_TIME_ZONE` to provide a default timezone that should be used to display dates/times in the front-end.

When users will be implemented, a timezone from the users profile should be used instead and the default display time zone will only be used as fall-back for users that are not logged in.