### PR TITLE
Add views to create/modify projects

### DIFF
--- a/dtf/forms.py
+++ b/dtf/forms.py
@@ -1,0 +1,14 @@
+from django import forms
+from django.forms import TextInput
+
+from dtf.models import Project
+
+class NewProjectForm(forms.ModelForm):
+
+    class Meta:
+        model = Project
+        fields = ['name', 'slug']
+        widgets = {
+            'name': TextInput(attrs={'placeholder': 'My new project'}),
+            'slug': TextInput(attrs={'placeholder': 'my-new-project'}),
+        }

--- a/dtf/forms.py
+++ b/dtf/forms.py
@@ -12,3 +12,9 @@ class NewProjectForm(forms.ModelForm):
             'name': TextInput(attrs={'placeholder': 'My new project'}),
             'slug': TextInput(attrs={'placeholder': 'my-new-project'}),
         }
+
+class ProjectSettingsForm(forms.ModelForm):
+
+    class Meta:
+        model = Project
+        fields = ['name', 'slug']

--- a/dtf/templates/dtf/bootstrap/field.html
+++ b/dtf/templates/dtf/bootstrap/field.html
@@ -1,0 +1,26 @@
+
+{% load dtf.custom_filters %}
+
+{% if field.is_hidden %}
+  {{ field }}
+{% else %}
+
+  {% if field.form.is_bound %}
+    {% if field.errors %}
+      {{ field|add_bootstrap_class:"is-invalid"}}
+      {% for error in field.errors %}
+        <div class="invalid-feedback">
+          {{ error }}
+        </div>
+      {% endfor %}
+    {% else %}
+      {{ field|add_bootstrap_class:"is-valid"}}
+    {% endif %}
+  {% else %}
+    {{ field|add_bootstrap_class}}
+  {% endif %}
+
+  {% if field.help_text %}
+    <small class="form-text text-muted">{{ field.help_text }}</small>
+  {% endif %}
+{% endif %}

--- a/dtf/templates/dtf/new_project.html
+++ b/dtf/templates/dtf/new_project.html
@@ -1,0 +1,56 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% block body %}
+
+<div class="bg-white sticky-top pt-3 pb-1">
+
+  <nav>
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'projects' %}">Project List</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">New</li>
+    </ol>
+  </nav>
+
+  <div class="page-header">
+    <div class="w-100">
+      <h1>New Project</h1>
+    </div>
+  </div>
+
+  <form action="{% url 'new_project' %}" method="post" novalidate>
+    {% csrf_token %}
+
+    {% for hidden_field in form.hidden_fields %}
+      {{ hidden_field }}
+    {% endfor %}
+
+    {% if form.non_field_errors %}
+      <div class="alert alert-danger" role="alert">
+        {% for error in form.non_field_errors %}
+          {{ error }}
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <div class="form-row">
+      <div class="form-group col-md">
+        {{ form.name.label_tag }}
+        {{ form.name|as_bootstrap_field }}
+      </div>
+      <div class="form-group col-">
+        {{ form.slug.label_tag }}
+        {{ form.slug|as_bootstrap_field }}
+      </div>
+    </div>
+
+    <input type="submit" value="Create project" class="btn btn-success">
+    <a class="btn btn-outline-secondary float-right" href="{% url 'projects' %}">Cancel</a>
+  </form>
+
+</div>
+
+{% endblock %}

--- a/dtf/templates/dtf/project_details.html
+++ b/dtf/templates/dtf/project_details.html
@@ -16,8 +16,9 @@
 </nav>
 
 <div class="page-header">
-    <div class="w-100">
-        <h1>Submissions for {{project.name}}</h1>
+    <h1 class="float-left">Submissions for {{project.name}}</h1>
+    <div class="float-right">
+        <a href="{% url 'project_settings' project.slug %}" class="btn btn-primary">Settings</a>
     </div>
 </div>
 

--- a/dtf/templates/dtf/project_settings.html
+++ b/dtf/templates/dtf/project_settings.html
@@ -1,0 +1,67 @@
+{% extends 'dtf/base.html' %}
+
+{% load dtf.custom_filters %}
+
+{% block body %}
+
+<div class="bg-white sticky-top pt-3 pb-1">
+
+  <nav>
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'projects' %}">Project List</a>
+      </li>
+      <li class="breadcrumb-item" aria-current="page">
+        <a href="{% url 'project_details' project.slug %}">{{ project.name }}</a>
+      </li>
+      <li class="breadcrumb-item active" aria-current="page">Settings</li>
+    </ol>
+  </nav>
+
+  <div class="page-header">
+    <div class="w-100">
+      <h1>Settings for {{ project.name }}</h1>
+    </div>
+  </div>
+
+  <h3>General</h3>
+  <form action="{% url 'project_settings' project.slug %}" method="post" novalidate>
+    {% csrf_token %}
+
+    <!-- General -->
+
+    {% for hidden_field in form.hidden_fields %}
+      {{ hidden_field }}
+    {% endfor %}
+
+    {% if form.non_field_errors %}
+      <div class="alert alert-danger" role="alert">
+        {% for error in form.non_field_errors %}
+          {{ error }}
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <div class="form-row">
+      <div class="form-group col-md">
+        {{ form.name.label_tag }}
+        {{ form.name|as_bootstrap_field }}
+      </div>
+      <div class="form-group col-">
+        {{ form.slug.label_tag }}
+        {{ form.slug|as_bootstrap_field }}
+      </div>
+      <div class="form-group col-">
+        <label for="project_id">ID:</label>
+        <input type="text" id="project_id" class="form-control" value="{{ project.id }}" disabled>
+      </div>
+    </div>
+
+    <input type="submit" value="Save" class="btn btn-success">
+    <a class="btn btn-outline-secondary float-right" href="{% url 'project_details' project.slug %}">Cancel</a>
+  </form>
+
+</div>
+
+
+{% endblock %}

--- a/dtf/templates/dtf/view_projects.html
+++ b/dtf/templates/dtf/view_projects.html
@@ -12,7 +12,12 @@
   </ol>
 </nav>
 
-<h2>List of all projects:</h2>
+<div class="page-header">
+    <h2 class="float-left">Projects</h2>
+    <div class="float-right">
+        <a href="{% url 'new_project' %}" class="btn btn-success">New project</a>
+    </div>
+</div>
 
 </div>
 

--- a/dtf/templatetags/dtf/custom_filters.py
+++ b/dtf/templatetags/dtf/custom_filters.py
@@ -1,5 +1,8 @@
 from django import template
+from django.template import Context
+from django.template.loader import get_template
 from django.utils.safestring import mark_safe
+from django import forms
 
 from dtf.settings import STATUS_TEXT_COLORS
 
@@ -49,3 +52,27 @@ def parse_json_table(text):
         out+="</tr>"
     out+="</table>"
     return mark_safe(out)
+
+@register.filter
+def as_bootstrap_field(field):
+    if not isinstance(field, forms.BoundField):
+        return field
+    attributes = {'field': field}
+    template = get_template("dtf/bootstrap/field.html")
+    context = Context(attributes).flatten()
+    return template.render(context)
+
+@register.filter
+def add_bootstrap_class(field, add_class=""):
+    if not isinstance(field, forms.BoundField):
+        return field
+
+    bootstrap_classes_per_widget = {
+        "text": "form-control",
+        "checkbox" : "form-check-input",
+    }
+
+    current_class = field.field.widget.attrs.get('class', None)
+    bootstrap_class = bootstrap_classes_per_widget.get(field.widget_type, None)
+    new_class = ' '.join(filter(None, [current_class, bootstrap_class, add_class]))
+    return field.as_widget(attrs={'class' : new_class})

--- a/dtf/urls.py
+++ b/dtf/urls.py
@@ -9,6 +9,7 @@ from dtf import views
 urlpatterns = [
     path('', views.frontpage),
     path('projects/', views.view_projects, name='projects'),
+    path('projects/new', views.view_new_project, name='new_project'),
     path('<str:project_slug>', views.view_project_details, name='project_details'),
     path('submission_details/<int:submission_id>', views.view_submission_details, name='submission_details'),
     path('test_details/<int:test_id>', views.view_test_result_details, name='test_result_details'),

--- a/dtf/urls.py
+++ b/dtf/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('projects/', views.view_projects, name='projects'),
     path('projects/new', views.view_new_project, name='new_project'),
     path('<str:project_slug>', views.view_project_details, name='project_details'),
+    path('<str:project_slug>/settings', views.view_project_settings, name='project_settings'),
     path('submission_details/<int:submission_id>', views.view_submission_details, name='submission_details'),
     path('test_details/<int:test_id>', views.view_test_result_details, name='test_result_details'),
 

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -1,5 +1,7 @@
 from django.shortcuts import render, get_object_or_404
 from django.db import IntegrityError
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -11,7 +13,7 @@ from dtf.serializers import TestReferenceSerializer
 from dtf.serializers import SubmissionSerializer
 from dtf.models import TestResult, Project, TestReference, Submission
 from dtf.functions import create_view_data_from_test_references
-
+from dtf.forms import NewProjectForm
 
 """
 User views
@@ -24,6 +26,18 @@ def frontpage(request):
 def view_projects(request):
     projects = Project.objects.order_by('-name')
     return render(request, 'dtf/view_projects.html', {'projects':projects})
+
+def view_new_project(request):
+    if request.method == 'POST':
+        form = NewProjectForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return HttpResponseRedirect(reverse('projects'))
+    else:
+        form = NewProjectForm()
+    return render(request, 'dtf/new_project.html', {
+        'form': form}
+    )
 
 def view_project_details(request, project_slug):
     project = get_object_or_404(Project, slug=project_slug)

--- a/dtf/views.py
+++ b/dtf/views.py
@@ -13,7 +13,7 @@ from dtf.serializers import TestReferenceSerializer
 from dtf.serializers import SubmissionSerializer
 from dtf.models import TestResult, Project, TestReference, Submission
 from dtf.functions import create_view_data_from_test_references
-from dtf.forms import NewProjectForm
+from dtf.forms import NewProjectForm, ProjectSettingsForm
 
 """
 User views
@@ -38,6 +38,21 @@ def view_new_project(request):
     return render(request, 'dtf/new_project.html', {
         'form': form}
     )
+
+def view_project_settings(request, project_slug):
+    project = get_object_or_404(Project, slug=project_slug)
+
+    if request.method == 'POST':
+        form = ProjectSettingsForm(request.POST, instance=project)
+        if form.is_valid():
+            form.save()
+    else:
+        form = ProjectSettingsForm(instance=project)
+
+    return render(request, 'dtf/project_settings.html', {
+        'project': project,
+        'form': form
+    })
 
 def view_project_details(request, project_slug):
     project = get_object_or_404(Project, slug=project_slug)


### PR DESCRIPTION
This PR adds new frontend views to create a new project or add an existing one.

To this end a "New Project" button has been added to the project list view:
![image](https://user-images.githubusercontent.com/6369416/101031892-0587cc00-357a-11eb-96ce-8ecb2571d266.png)

The new project view is currently very simple. You can only specify the project name and a slug:
![image](https://user-images.githubusercontent.com/6369416/101032171-1b958c80-357a-11eb-9a0c-cc8b3dfcd091.png)

Invalid form inputs are presented to the user according to the bootstrap theme:
![image](https://user-images.githubusercontent.com/6369416/101032889-513a7580-357a-11eb-93dc-600e45bab912.png)

To modify an existing project a "Settings" button has been added to the projects details view:
![image](https://user-images.githubusercontent.com/6369416/101032445-2d772f80-357a-11eb-91f6-7fa49137fa2e.png)

Currently the project settings does only allow to change the project name and its slug. The project ID is non-mutable:
![image](https://user-images.githubusercontent.com/6369416/101032597-3831c480-357a-11eb-85f9-2eb709695bc0.png)

This PR is based on #30 and requires that to be merged first.